### PR TITLE
[MOD] MouseEvent bool _isPressed changed for ButtonState _state

### DIFF
--- a/include/events/MouseEvent.hpp
+++ b/include/events/MouseEvent.hpp
@@ -21,12 +21,12 @@ namespace arcade {
             Right
         };
 
-        MouseEvent(double x, double y, bool pressed = false, const Button &button = None)
-            : _btn(button), _x(x), _y(y), _isPressed(pressed){};
+        MouseEvent(double x, double y, ButtonState state = ButtonState::None, Button button = None)
+            : _btn(button), _x(x), _y(y), _state(state) {};
 
         Button _btn;
         double _x;
         double _y;
-        bool _isPressed;
+        ButtonState _state;
     };
 }


### PR DESCRIPTION
Use IEvent::ButtonState instead of a boolean to describe state of mouse button